### PR TITLE
Python app support

### DIFF
--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -59,3 +59,39 @@
     directory_mode: yes
   when: item.value.initializers is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
+
+
+# The following are tasks to create (and use) a python virtual environment 
+# for apps that have the "python_environment property defined.
+- name: Create Python virtual environment
+  command: python3 -m venv "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
+  args:
+    creates: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
+  when: item.value.python_environment is defined
+  loop: "{{ ood_apps | default({}) | dict2items }}"
+
+- name: Install Python dependencies from requirements.txt
+  pip:
+    requirements: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/requirements.txt"
+    virtualenv: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
+  when:
+    - item.value.python_environment is defined
+    - ansible.builtin.file.stat.exists("{{ ood_base_conf_dir }}/apps/{{ item.key }}/requirements.txt")
+  loop: "{{ ood_apps | default({}) | dict2items }}"
+
+- name: Create custom python executable
+  copy:
+    content: |
+      #!/usr/bin/env bash
+
+      SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+      source $SCRIPT_DIR/../venv/bin/activate
+
+      export PYTHONNOUSERSITE=1
+
+      exec /usr/bin/env python3 "$@"
+    dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/bin/python"
+    mode: '0755'
+  when: item.value.python_environment is defined
+  loop: "{{ ood_apps | default({}) | dict2items }}"
+  

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -78,6 +78,14 @@
     - item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
+- name: Create executable folder
+  ansible.builtin.file:
+    path: "{{ ood_sys_app_dir }}/{{ item.key }}/bin"
+    state: directory
+    mode: '0755'
+  when: item.value.python_environment is defined
+  loop: "{{ ood_apps | default({}) | dict2items }}"
+  
 - name: Create custom python executable
   copy:
     content: |

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -64,16 +64,16 @@
 # The following are tasks to create (and use) a python virtual environment 
 # for apps that have the "python_environment property defined.
 - name: Create Python virtual environment
-  command: python3 -m venv "{{ ood_app_dir }}/{{ item.key }}/venv"
+  command: python3 -m venv "{{ ood_sys_app_dir }}/{{ item.key }}/venv"
   args:
-    creates: "{{ ood_app_dir }}/{{ item.key }}/venv"
+    creates: "{{ ood_sys_app_dir }}/{{ item.key }}/venv"
   when: item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Install Python dependencies from requirements.txt
   pip:
-    requirements: "{{ ood_app_dir }}/{{ item.key }}/requirements.txt"
-    virtualenv: "{{ ood_app_dir }}/{{ item.key }}/venv"
+    requirements: "{{ ood_sys_app_dir }}/{{ item.key }}/requirements.txt"
+    virtualenv: "{{ ood_sys_app_dir }}/{{ item.key }}/venv"
   when:
     - item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
@@ -89,7 +89,7 @@
       export PYTHONNOUSERSITE=1
 
       exec /usr/bin/env python3 "$@"
-    dest: "{{ ood_app_dir }}/{{ item.key }}/bin/python"
+    dest: "{{ ood_sys_app_dir }}/{{ item.key }}/bin/python"
     mode: '0755'
   when: item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -64,18 +64,18 @@
 # The following are tasks to create (and use) a python virtual environment 
 # for apps that have the "python_environment property defined.
 - name: Create Python virtual environment
-  command: python3 -m venv "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
+  command: python3 -m venv "{{ ood_app_dir }}/{{ item.key }}/venv"
   args:
-    creates: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
+    creates: "{{ ood_app_dir }}/{{ item.key }}/venv"
   when: item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Install Python dependencies from requirements.txt
   pip:
-    requirements: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/requirements.txt"
-    virtualenv: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
+    requirements: "{{ ood_app_dir }}/{{ item.key }}/requirements.txt"
+    virtualenv: "{{ ood_app_dir }}/{{ item.key }}/venv"
   when:
-    - item.value.python_environment is defined  
+    - item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Create custom python executable
@@ -89,7 +89,7 @@
       export PYTHONNOUSERSITE=1
 
       exec /usr/bin/env python3 "$@"
-    dest: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/bin/python"
+    dest: "{{ ood_app_dir }}/{{ item.key }}/bin/python"
     mode: '0755'
   when: item.value.python_environment is defined
   loop: "{{ ood_apps | default({}) | dict2items }}"

--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -75,8 +75,7 @@
     requirements: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/requirements.txt"
     virtualenv: "{{ ood_base_conf_dir }}/apps/{{ item.key }}/venv"
   when:
-    - item.value.python_environment is defined
-    - ansible.builtin.file.stat.exists("{{ ood_base_conf_dir }}/apps/{{ item.key }}/requirements.txt")
+    - item.value.python_environment is defined  
   loop: "{{ ood_apps | default({}) | dict2items }}"
 
 - name: Create custom python executable


### PR DESCRIPTION
This PR adds the following steps to the app deployment of ood apps:
1. If the app has python_environment set it runs a few steps that create a virtual environment for the app and an appropriate python binary wrapper
2. The wrapper will use the python from the environment AND ignore all user site packages
3. The apps need to have the following format:
    - manifest.yml
    - requirements.txt
    - passenger_wsgi.py (startup file for the app)
4. the manifest needs to have the following format:
   ```
   name: <Name of the App>
   description: < description of the app >
   icon: <icon for the app e.g. fas://chart-bar >
   category: < Category in the menu e.g. Jobs. NOTE: Applications cannot be used on our OOD since that category is manually populated >
   subcategory: < Subcategory e.g. Utilities>
   ```
   
   Please squash commits on merge. 